### PR TITLE
Update the docker image for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/python:3.8.5-browsers
+      - image: circleci/python:3.8.5
     working_directory: ~/mignonnesaurus-blog
     steps:
       - browser-tools/install-firefox


### PR DESCRIPTION
Use `python:3.8.5` instead of `python:3.8.5-browsers` since we are getting the browser tools from `circleci/browser-tools@1.0.1`.