### PR TITLE
Fix CodeQL GitHub action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,13 +1,8 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [master, ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [master]
-  schedule:
-    - cron: '0 8 * * 2'
 
 jobs:
   analyse:


### PR DESCRIPTION
#### Fixes 

It fixes the failures of the CodeQL analysis GitHub action. For example: https://github.com/eliflores/mignonnesaurus-blog/runs/2687215196. 

The fix is to only run the CodeQL workflow on the "pull_request" event and avoid triggering it on the "push" event for Dependabot branches because workflows triggered by Dependabot on the "push" event run with read-only access, and uploading Code Scanning results requires write access.