### PR TITLE
Update version of circleci browser-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.0.1
+  browser-tools: circleci/browser-tools@1.2.1
 jobs:
   build:
     docker:


### PR DESCRIPTION
#### Fixes 

There is a new version of [CircleCI browser-tools](https://circleci.com/developer/orbs/orb/circleci/browser-tools)