### PR TITLE
Fix dependabot package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-- package-ecosystem: pipenv
+- package-ecosystem: pip
   directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
#### Fixes 

It fixed the error
```
The property '#/updates/0/package-ecosystem' value "pipenv" did not match one of the following values: npm, bundler, composer, maven, mix, cargo, gradle, nuget, gomod, docker, elm, gitsubmodule, github-actions, pip, terraform
```

#### Additional comments 

Read the [instructions](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates) wrong 🤦‍♀️ and the value should be `pip` when the package manager is `pipenv`, so we did not need to update this file 💃

Introduced issue in PR #517.