### PR TITLE
Use SQLite also for Dev Settings

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -103,7 +103,12 @@ class Local(Base):
 class Dev(Base):
     DEBUG = True
 
-    DATABASES = {'default': dj_database_url.config(conn_max_age=500)}
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        }
+    }
 
     ALLOWED_HOSTS = [
         '.herokuapp.com',


### PR DESCRIPTION
#### Description

Since these are the Settings that are used for Preview Apps, and the Preview Apps have a dynamic / temporary PostgreSQL instance, we can't use a static DATABASE_URL reference.
Having an SQLite for Preview Apps would work, since with this, we only want to verify that the app is successfully deployed and that it can start with no errors.

#### Fixes 

Errors on Preview Apps.