### PR TITLE
Fix deployment

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -115,7 +115,7 @@ class Dev(Base):
 
 
 class Staging(Base):
-    DEBUG = True
+    DEBUG = False
 
     DATABASES = {'default': dj_database_url.config(conn_max_age=500)}
 
@@ -136,7 +136,7 @@ class Staging(Base):
 
 
 class Prod(Base):
-    DEBUG = True
+    DEBUG = False
 
     DATABASES = {'default': dj_database_url.config(conn_max_age=500)}
 

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -102,7 +102,11 @@ class Dev(Base):
         '.herokuapp.com',
     ]
 
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+    STORAGES = {
+        'staticfiles': {
+            'BACKEND': 'whitenoise.storage.CompressedManifestStaticFilesStorage',
+        },
+    }
 
     SECURE_SSL_REDIRECT = True
 
@@ -119,7 +123,11 @@ class Staging(Base):
         'mignonnesaurus-staging.herokuapp.com',
     ]
 
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+    STORAGES = {
+        'staticfiles': {
+            'BACKEND': 'whitenoise.storage.CompressedManifestStaticFilesStorage',
+        },
+    }
 
     SECURE_SSL_REDIRECT = True
 
@@ -137,7 +145,11 @@ class Prod(Base):
         'mignonnesaurus.herokuapp.com',
     ]
 
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+    STORAGES = {
+        'staticfiles': {
+            'BACKEND': 'whitenoise.storage.CompressedManifestStaticFilesStorage',
+        },
+    }
 
     SECURE_SSL_REDIRECT = True
 


### PR DESCRIPTION
Remove the old DEFAULT_FILE_STORAGE and STATICFILES_STORAGE settings that were deprecated in Django 4.2.

#### Fixes 

The depoloyment issues in https://app.circleci.com/pipelines/github/eliflores/mignonnesaurus-blog/2041/workflows/1117f71e-efc2-4bd2-b2d5-0536b452fb59/jobs/2523:

```
Traceback (most recent call last):        
remote:          File "/app/.heroku/python/lib/python3.9/site-packages/django/core/management/__init__.py", line 255, in fetch_command        
remote:            app_name = commands[subcommand]        
remote:        KeyError: 'collectstatic'        
remote:        During handling of the above exception, another exception occurred:        
remote:        Traceback (most recent call last):        
remote:          File "/tmp/build_90214c05/manage.py", line 11, in <module>        
remote:            execute_from_command_line(sys.argv)        
remote:          File "/app/.heroku/python/lib/python3.9/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line        
remote:            utility.execute()        
remote:          File "/app/.heroku/python/lib/python3.9/site-packages/django/core/management/__init__.py", line 436, in execute        
remote:            self.fetch_command(subcommand).run_from_argv(self.argv)        
remote:          File "/app/.heroku/python/lib/python3.9/site-packages/django/core/management/__init__.py", line 262, in fetch_command        
remote:            settings.INSTALLED_APPS        
remote:          File "/app/.heroku/python/lib/python3.9/site-packages/django/conf/__init__.py", line 102, in __getattr__        
remote:            self._setup(name)        
remote:          File "/app/.heroku/python/lib/python3.9/site-packages/django/conf/__init__.py", line 89, in _setup        
remote:            self._wrapped = Settings(settings_module)        
remote:          File "/app/.heroku/python/lib/python3.9/site-packages/django/conf/__init__.py", line 278, in __init__        
remote:            raise ImproperlyConfigured(        
remote:        django.core.exceptions.ImproperlyConfigured: STATICFILES_STORAGE/STORAGES are mutually exclusive.        
remote: 
remote:  !     Error while running '$ python manage.py collectstatic --noinput'.        
remote:        See traceback above for details. 
```