### PR TITLE
Chore/bump ci deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.4.8
+  browser-tools: circleci/browser-tools@1.5.1
 jobs:
   test:
     docker:
-      - image: cimg/python:3.10.14-browsers
+      - image: cimg/python:3.12.9-browsers
         environment:
           PIPENV_VENV_IN_PROJECT: true
     working_directory: ~/mignonnesaurus-blog

--- a/Pipfile
+++ b/Pipfile
@@ -36,4 +36,4 @@ setuptools = "==75.8.0"
 [dev-packages]
 
 [requires]
-python_version = "3.10"
+python_version = "3.12"


### PR DESCRIPTION
#### Fixes 

The following CI error, in the Install Firefox step:
```
Latest stable version of Firefox is 135.0
A different version of Firefox is installed (Mozilla Firefox 125.0); removing it
....
curl: (22) The requested URL returned error: 404

Exited with code exit status 22
```

#### Screenshots 


#### Additional comments 